### PR TITLE
난이도별 멤버 당 균등한 비율의 카드 선택

### DIFF
--- a/Assets/Animations/card_images.anim
+++ b/Assets/Animations/card_images.anim
@@ -21,7 +21,7 @@ AnimationClip:
   - serializedVersion: 2
     curve:
     - time: 0
-      value: {fileID: 21300000, guid: 6572968426984854b898afa26ec02e8e, type: 3}
+      value: {fileID: 21300000, guid: 37a1765a4f09ab24caaeebda1c3a0de9, type: 3}
     - time: 0.31666666
       value: {fileID: 21300000, guid: 51dd5f0cb9684724b81f672c48495208, type: 3}
     - time: 0.65
@@ -51,7 +51,7 @@ AnimationClip:
     - time: 4.65
       value: {fileID: 21300000, guid: c9ed3b5788e36794ebef83d11563dccf, type: 3}
     - time: 4.983333
-      value: {fileID: 21300000, guid: 6572968426984854b898afa26ec02e8e, type: 3}
+      value: {fileID: 21300000, guid: 37a1765a4f09ab24caaeebda1c3a0de9, type: 3}
     attribute: m_Sprite
     path: 
     classID: 114
@@ -74,7 +74,7 @@ AnimationClip:
       isIntCurve: 0
       isSerializeReferenceCurve: 0
     pptrCurveMapping:
-    - {fileID: 21300000, guid: 6572968426984854b898afa26ec02e8e, type: 3}
+    - {fileID: 21300000, guid: 37a1765a4f09ab24caaeebda1c3a0de9, type: 3}
     - {fileID: 21300000, guid: 51dd5f0cb9684724b81f672c48495208, type: 3}
     - {fileID: 21300000, guid: aaa95493bc7d5d54197375690de3cae5, type: 3}
     - {fileID: 21300000, guid: bad92bb5198b91041bc2441fe6e86b57, type: 3}
@@ -89,7 +89,7 @@ AnimationClip:
     - {fileID: 21300000, guid: 0242610e1e8ea2b4e9c01ccf701ae365, type: 3}
     - {fileID: 21300000, guid: dfae2a449ed62ff4c8256c2b253d6b80, type: 3}
     - {fileID: 21300000, guid: c9ed3b5788e36794ebef83d11563dccf, type: 3}
-    - {fileID: 21300000, guid: 6572968426984854b898afa26ec02e8e, type: 3}
+    - {fileID: 21300000, guid: 37a1765a4f09ab24caaeebda1c3a0de9, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}

--- a/Assets/Scripts/gameManager.cs
+++ b/Assets/Scripts/gameManager.cs
@@ -45,17 +45,34 @@ public class gameManager : MonoBehaviour
             images = new int[10]; // Easy 난이도는 10개 이미지
             for (int i = 0; i < images.Length / 2; i++)
             {
-                images[2 * i] = i;
-                images[2 * i + 1] = i;
+                // 인당 준비된 세 종류 카드 중 랜덤하게 하나씩 선택
+                int randomValue = UnityEngine.Random.Range(0, 3);
+                images[2 * i] = i + randomValue;
+                images[2 * i + 1] = i + randomValue;
             }
         }
         else if (difficulty == "Normal")
         {
             images = new int[20]; // Normal 난이도는 20개 이미지
+            
+            // 인당 준비된 세 종류 카드 중 앞 두개 카드 선택.(랜덤하게 선택하기엔 아이디어부족+코드 길어짐)
+            int value = 0; // 실제 images 배열에 넣을 값
+
             for (int i = 0; i < images.Length / 2; i++)
             {
-                images[2 * i] = i;
-                images[2 * i + 1] = i;
+                // 배열에 값을 할당
+                images[2 * i] = value;
+                images[2 * i + 1] = value;
+
+                // 다음 값으로 증가시킴. 2, 5, 8, 11, 14는 건너뛰기
+                if (value == 1 || value == 4 || value == 7 || value == 10 || value == 13)
+                {
+                    value += 2; // 2, 5, 8, 11, 14를 건너뛰기 위해 2 증가
+                }
+                else
+                {
+                    value += 1; // 그 외에는 1 증가
+                }
             }
         }
         else // Hard 또는 기타


### PR DESCRIPTION
Easy에서는 image0~image4 / Normal에서는 image0~image9를 선택하여 특정 멤버만 선택되던 현상 수정.
gameManager.cs 의 카드 선정 파트를 편집

(리퀘스트 취소...)