### PR TITLE
난이도별 멤버 당 균등한 비율의 카드 선택, 코드 내 한글주석 영문화

### DIFF
--- a/Assets/Animations/card_images.anim
+++ b/Assets/Animations/card_images.anim
@@ -21,7 +21,7 @@ AnimationClip:
   - serializedVersion: 2
     curve:
     - time: 0
-      value: {fileID: 21300000, guid: 6572968426984854b898afa26ec02e8e, type: 3}
+      value: {fileID: 21300000, guid: 37a1765a4f09ab24caaeebda1c3a0de9, type: 3}
     - time: 0.31666666
       value: {fileID: 21300000, guid: 51dd5f0cb9684724b81f672c48495208, type: 3}
     - time: 0.65
@@ -51,7 +51,7 @@ AnimationClip:
     - time: 4.65
       value: {fileID: 21300000, guid: c9ed3b5788e36794ebef83d11563dccf, type: 3}
     - time: 4.983333
-      value: {fileID: 21300000, guid: 6572968426984854b898afa26ec02e8e, type: 3}
+      value: {fileID: 21300000, guid: 37a1765a4f09ab24caaeebda1c3a0de9, type: 3}
     attribute: m_Sprite
     path: 
     classID: 114
@@ -74,7 +74,7 @@ AnimationClip:
       isIntCurve: 0
       isSerializeReferenceCurve: 0
     pptrCurveMapping:
-    - {fileID: 21300000, guid: 6572968426984854b898afa26ec02e8e, type: 3}
+    - {fileID: 21300000, guid: 37a1765a4f09ab24caaeebda1c3a0de9, type: 3}
     - {fileID: 21300000, guid: 51dd5f0cb9684724b81f672c48495208, type: 3}
     - {fileID: 21300000, guid: aaa95493bc7d5d54197375690de3cae5, type: 3}
     - {fileID: 21300000, guid: bad92bb5198b91041bc2441fe6e86b57, type: 3}
@@ -89,7 +89,7 @@ AnimationClip:
     - {fileID: 21300000, guid: 0242610e1e8ea2b4e9c01ccf701ae365, type: 3}
     - {fileID: 21300000, guid: dfae2a449ed62ff4c8256c2b253d6b80, type: 3}
     - {fileID: 21300000, guid: c9ed3b5788e36794ebef83d11563dccf, type: 3}
-    - {fileID: 21300000, guid: 6572968426984854b898afa26ec02e8e, type: 3}
+    - {fileID: 21300000, guid: 37a1765a4f09ab24caaeebda1c3a0de9, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}

--- a/Assets/Resources/image0.png.meta
+++ b/Assets/Resources/image0.png.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
-
 guid: 37a1765a4f09ab24caaeebda1c3a0de9
-
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/Assets/Scripts/gameManager.cs
+++ b/Assets/Scripts/gameManager.cs
@@ -45,17 +45,34 @@ public class gameManager : MonoBehaviour
             images = new int[10]; // Easy 난이도는 10개 이미지
             for (int i = 0; i < images.Length / 2; i++)
             {
-                images[2 * i] = i;
-                images[2 * i + 1] = i;
+                // 인당 준비된 세 종류 카드 중 랜덤하게 하나씩 선택
+                int randomValue = UnityEngine.Random.Range(0, 3);
+                images[2 * i] = i + randomValue;
+                images[2 * i + 1] = i + randomValue;
             }
         }
         else if (difficulty == "Normal")
         {
             images = new int[20]; // Normal 난이도는 20개 이미지
+            
+            // 인당 준비된 세 종류 카드 중 앞 두개 카드 선택.(랜덤하게 선택하기엔 아이디어부족+코드 길어짐)
+            int value = 0; // 실제 images 배열에 넣을 값
+
             for (int i = 0; i < images.Length / 2; i++)
             {
-                images[2 * i] = i;
-                images[2 * i + 1] = i;
+                // 배열에 값을 할당
+                images[2 * i] = value;
+                images[2 * i + 1] = value;
+
+                // 다음 값으로 증가시킴. 2, 5, 8, 11, 14는 건너뛰기
+                if (value == 1 || value == 4 || value == 7 || value == 10 || value == 13)
+                {
+                    value += 2; // 2, 5, 8, 11, 14를 건너뛰기 위해 2 증가
+                }
+                else
+                {
+                    value += 1; // 그 외에는 1 증가
+                }
             }
         }
         else // Hard 또는 기타

--- a/Assets/Scripts/gameManager.cs
+++ b/Assets/Scripts/gameManager.cs
@@ -23,16 +23,6 @@ public class gameManager : MonoBehaviour
 
     public GameObject NowDifficulty;
 
-    // 이미지 리소스 이름 수정에 따라 nameMap 작성
-    private Dictionary<int, string> nameMap = new Dictionary<int, string>
-    {
-        { 0, "김소이" },
-        { 1, "이승배" },
-        { 2, "이도현" },
-        { 3, "김성우" },
-        { 4, "김준하" }
-    };
-
     void Awake()
     {
         I = this;
@@ -44,51 +34,48 @@ public class gameManager : MonoBehaviour
         Time.timeScale = 1.0f;
         audioSource.PlayOneShot(shuffle);
 
-        // 난이도에 따른 이미지 갯수 조정
+        // Adjusting the Number of Cards According to Difficulty
         int[] images;
         NowDifficulty = GameObject.Find("NowDifficulty");
         string difficulty = NowDifficulty.GetComponent<nowDifficulty>().difficulty;
 
-
-
+        // Easy : 10 Cards(5 Types)
         if (difficulty == "Easy")
         {
-            images = new int[10]; // Easy 난이도는 10개 이미지
+            images = new int[10];
             for (int i = 0; i < images.Length / 2; i++)
             {
-                // 인당 준비된 세 종류 카드 중 랜덤하게 하나씩 선택
                 int randomValue = UnityEngine.Random.Range(0, 3);
                 images[2 * i] = i + randomValue;
                 images[2 * i + 1] = i + randomValue;
             }
         }
+        // Normal : 20 Cards(10 Types)
         else if (difficulty == "Normal")
         {
-            images = new int[20]; // Normal 난이도는 20개 이미지
+            images = new int[20]; 
             
-            // 인당 준비된 세 종류 카드 중 앞 두개 카드 선택.(랜덤하게 선택하기엔 아이디어부족+코드 길어짐)
-            int value = 0; // 실제 images 배열에 넣을 값
+            int value = 0; 
 
             for (int i = 0; i < images.Length / 2; i++)
             {
-                // 배열에 값을 할당
                 images[2 * i] = value;
                 images[2 * i + 1] = value;
 
-                // 다음 값으로 증가시킴. 2, 5, 8, 11, 14는 건너뛰기
                 if (value == 1 || value == 4 || value == 7 || value == 10 || value == 13)
                 {
-                    value += 2; // 2, 5, 8, 11, 14를 건너뛰기 위해 2 증가
+                    value += 2;
                 }
                 else
                 {
-                    value += 1; // 그 외에는 1 증가
+                    value += 1;
                 }
             }
         }
-        else // Hard 또는 기타
+        // Hard : 30 Cards(15 Types)
+        else
         {
-            images = new int[30]; // Hard 난이도는 30개 이미지
+            images = new int[30];
             for (int i = 0; i < images.Length / 2; i++)
             {
                 images[2 * i] = i;
@@ -96,10 +83,10 @@ public class gameManager : MonoBehaviour
             }
         }
 
-        // 카드를 섞는 원래 코드
+        // shuffling cards (Before)
         //images = images.OrderBy(item => Random.Range(-1.0f, 1.0f)).ToArray();
 
-        // 카드를 섞는 새로운 코드
+        // shuffling cards (After)
         for (int i = 0; i < images.Length; i++)
         {
             int randomIndex = UnityEngine.Random.Range(0, images.Length);
@@ -108,8 +95,7 @@ public class gameManager : MonoBehaviour
             images[randomIndex] = temp;
         }
 
-
-        // 난이도별로 다른 카드 배치
+        // Set Card Position & Get sprite : EASY
         if (difficulty == "Easy")
         {
             for (int i = 0; i < 10; i++)
@@ -134,17 +120,11 @@ public class gameManager : MonoBehaviour
                 }
                 newCard.transform.position = new Vector3(x, y, 0);
 
-                // 기존 스프라이트 이미지 리소스 이름 선정
-                //string imageName = "image" + images[i].ToString();
-
-                // 이미지 리소스 수정에 따른 스프라이트 이름 선정
-                int nameNum = images[i] / 3;
-                int subNum = images[i] % 3 + 1;
-                string imageName = ConvertIntToName(nameNum) + subNum.ToString();
-
+                string imageName = "image" + images[i].ToString();
                 newCard.transform.Find("front").GetComponent<SpriteRenderer>().sprite = Resources.Load<Sprite>(imageName);
             }
         }
+        // Set Card Position & Get sprite : Normal
         else if (difficulty == "Normal")
         {
             for (int i = 0; i < 20; i++)
@@ -156,18 +136,12 @@ public class gameManager : MonoBehaviour
                 float y = (i % 5) * 1.3f - 3.6f;
                 newCard.transform.position = new Vector3(x, y, 0);
 
-                // 기존 스프라이트 이미지 리소스 이름 선정
-                // string imageName = "image" + images[i].ToString();
-
-                // 이미지 리소스 수정에 따른 스프라이트 이름 선정
-                int nameNum = images[i] / 3;
-                int subNum = images[i] % 3 + 1;
-                string imageName = ConvertIntToName(nameNum) + subNum.ToString();
-
+                string imageName = "image" + images[i].ToString();
                 newCard.transform.Find("front").GetComponent<SpriteRenderer>().sprite = Resources.Load<Sprite>(imageName);
             }
 
         }
+        // Set Card Position & Get sprite : Hard
         else
         {
             for (int i = 0; i < 30; i++)
@@ -179,18 +153,10 @@ public class gameManager : MonoBehaviour
                 float y = (i % 6) * 1.3f - 3.6f;
                 newCard.transform.position = new Vector3(x, y, 0);
 
-                // 기존 스프라이트 이미지 리소스 이름 선정
-                // string imageName = "image" + images[i].ToString();
-
-                // 이미지 리소스 수정에 따른 스프라이트 이름 선정
-                int nameNum = images[i] / 3;
-                int subNum = images[i] % 3 + 1;
-                string imageName = ConvertIntToName(nameNum) + subNum.ToString();
-
+                string imageName = "image" + images[i].ToString();
                 newCard.transform.Find("front").GetComponent<SpriteRenderer>().sprite = Resources.Load<Sprite>(imageName);
             }
         }
-
     }
 
     // Update is called once per frame
@@ -233,17 +199,6 @@ public class gameManager : MonoBehaviour
 
         firstCard = null;
         secondCard = null;
-    }
-
-    // 이름 매핑 함수
-    string ConvertIntToName(int value)
-    {
-        if (nameMap.TryGetValue(value, out string name))
-        {
-            return name;
-        }
-
-        return "Unknown"; // 사전에 정의되지 않은 값의 경우
     }
 
 }

--- a/Assets/Scripts/gameManager.cs
+++ b/Assets/Scripts/gameManager.cs
@@ -23,6 +23,15 @@ public class gameManager : MonoBehaviour
 
     public GameObject NowDifficulty;
 
+    // 이미지 리소스 이름 수정에 따라 nameMap 작성
+    private Dictionary<int, string> nameMap = new Dictionary<int, string>
+    {
+        { 0, "김소이" },
+        { 1, "이승배" },
+        { 2, "이도현" },
+        { 3, "김성우" },
+        { 4, "김준하" }
+    };
 
     void Awake()
     {
@@ -39,6 +48,8 @@ public class gameManager : MonoBehaviour
         int[] images;
         NowDifficulty = GameObject.Find("NowDifficulty");
         string difficulty = NowDifficulty.GetComponent<nowDifficulty>().difficulty;
+
+
 
         if (difficulty == "Easy")
         {
@@ -123,7 +134,14 @@ public class gameManager : MonoBehaviour
                 }
                 newCard.transform.position = new Vector3(x, y, 0);
 
-                string imageName = "image" + images[i].ToString();
+                // 기존 스프라이트 이미지 리소스 이름 선정
+                //string imageName = "image" + images[i].ToString();
+
+                // 이미지 리소스 수정에 따른 스프라이트 이름 선정
+                int nameNum = images[i] / 3;
+                int subNum = images[i] % 3 + 1;
+                string imageName = ConvertIntToName(nameNum) + subNum.ToString();
+
                 newCard.transform.Find("front").GetComponent<SpriteRenderer>().sprite = Resources.Load<Sprite>(imageName);
             }
         }
@@ -138,7 +156,14 @@ public class gameManager : MonoBehaviour
                 float y = (i % 5) * 1.3f - 3.6f;
                 newCard.transform.position = new Vector3(x, y, 0);
 
-                string imageName = "image" + images[i].ToString();
+                // 기존 스프라이트 이미지 리소스 이름 선정
+                // string imageName = "image" + images[i].ToString();
+
+                // 이미지 리소스 수정에 따른 스프라이트 이름 선정
+                int nameNum = images[i] / 3;
+                int subNum = images[i] % 3 + 1;
+                string imageName = ConvertIntToName(nameNum) + subNum.ToString();
+
                 newCard.transform.Find("front").GetComponent<SpriteRenderer>().sprite = Resources.Load<Sprite>(imageName);
             }
 
@@ -154,7 +179,14 @@ public class gameManager : MonoBehaviour
                 float y = (i % 6) * 1.3f - 3.6f;
                 newCard.transform.position = new Vector3(x, y, 0);
 
-                string imageName = "image" + images[i].ToString();
+                // 기존 스프라이트 이미지 리소스 이름 선정
+                // string imageName = "image" + images[i].ToString();
+
+                // 이미지 리소스 수정에 따른 스프라이트 이름 선정
+                int nameNum = images[i] / 3;
+                int subNum = images[i] % 3 + 1;
+                string imageName = ConvertIntToName(nameNum) + subNum.ToString();
+
                 newCard.transform.Find("front").GetComponent<SpriteRenderer>().sprite = Resources.Load<Sprite>(imageName);
             }
         }
@@ -201,6 +233,17 @@ public class gameManager : MonoBehaviour
 
         firstCard = null;
         secondCard = null;
+    }
+
+    // 이름 매핑 함수
+    string ConvertIntToName(int value)
+    {
+        if (nameMap.TryGetValue(value, out string name))
+        {
+            return name;
+        }
+
+        return "Unknown"; // 사전에 정의되지 않은 값의 경우
     }
 
 }


### PR DESCRIPTION
난이도별 멤버 당 균등한 비율의 카드 선택.
→ 스프라이트 이름 변경에 따라 선정 코드 변경
→ 스프라이트 이름 롤백에 따라 매핑 코드 롤백 및 원래 쓰여졌던 한글주석 영문화
gameManager.cs 주로 편집함.

+ 추가 메모
난이도 별 해금에 필요한 [이전 난이도 필요 점수]는 SelectDifficultyScene의 'SelectDifficulty'오브젝트의 인스펙터에서 수정 가능.
해당 필요 점수를 0 이하로 할 경우, 난이도 해금 됨.
Normal 또는 Hard 난이도 게임을 테스트 할 때 참고해주세요.