### PR TITLE
게임 결과 저장, fix:시작 시 이미지 중복선택 해결, fix:1번/3번

### DIFF
--- a/Assets/Scenes/SelectDifficultyScene.unity
+++ b/Assets/Scenes/SelectDifficultyScene.unity
@@ -1593,9 +1593,9 @@ MonoBehaviour:
   EasyScoreImg: {fileID: 255124606}
   NormalScoreImg: {fileID: 1806738486}
   HardScoreImg: {fileID: 423648776}
-  audiomanger: {fileID: 0}
+  audiomanager: {fileID: 0}
   canNormal: -1
-  canHard: 15
+  canHard: 40
   NowDifficulty: {fileID: 0}
 --- !u!4 &2127106815
 Transform:

--- a/Assets/Scripts/gameManager.cs
+++ b/Assets/Scripts/gameManager.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using UnityEngine;
+using UnityEngine.SocialPlatforms.Impl;
 using UnityEngine.UI;
 
 public class gameManager : MonoBehaviour
@@ -32,6 +33,8 @@ public class gameManager : MonoBehaviour
 
     int mCnt = 0;
     private bool isPlay;
+
+    public bool dataSaveWithFail;
 
     void Awake()
     {
@@ -191,7 +194,30 @@ public class gameManager : MonoBehaviour
         {
             remainTimeTxt.text = time.ToString("N2");
             matchCnt.text = mCnt.ToString();
-            scoreTxt.text = (50 - mCnt).ToString();
+
+            // calculate score & save
+            int score = (50 - mCnt);
+
+            // code for to save score test
+            if (dataSaveWithFail)
+            {
+                string difficulty = NowDifficulty.GetComponent<nowDifficulty>().difficulty;
+                float savedScore = 0f;
+                if (difficulty == "Easy") savedScore = PlayerPrefs.GetFloat("EasyScore", 0f);
+                if (difficulty == "Normal") savedScore = PlayerPrefs.GetFloat("NormalScore", 0f);
+                if (difficulty == "Hard") savedScore = PlayerPrefs.GetFloat("HardScore", 0f);
+                if (savedScore < score)
+                {
+                    if (difficulty == "Easy") PlayerPrefs.SetFloat("EasyScore", score);
+                    if (difficulty == "Normal") PlayerPrefs.SetFloat("NormalScore", score);
+                    if (difficulty == "Hard") PlayerPrefs.SetFloat("HardScore", score);
+                    PlayerPrefs.Save();
+                }
+            }
+
+
+            scoreTxt.text = score.ToString();
+
             endCanvas.SetActive(true);
             Time.timeScale = 0.0f;
         }
@@ -238,39 +264,20 @@ public class gameManager : MonoBehaviour
 
                 // calculate score & save
                 int score = (50 - mCnt + (int)Math.Round(time));
-                //if (time > 0.0f)
-                if (true)
+                string difficulty = NowDifficulty.GetComponent<nowDifficulty>().difficulty;
+                float savedScore = 0f;
+                if (difficulty == "Easy") savedScore = PlayerPrefs.GetFloat("EasyScore", 0f);
+                if (difficulty == "Normal") savedScore = PlayerPrefs.GetFloat("NormalScore", 0f);
+                if (difficulty == "Hard") savedScore = PlayerPrefs.GetFloat("HardScore", 0f);
+                if (savedScore < score)
                 {
-                    string difficulty = NowDifficulty.GetComponent<nowDifficulty>().difficulty;
-                    if (difficulty == "Easy")
-                    {
-                        float savedScore = PlayerPrefs.GetFloat("EasyScore", 0f);
-                        if (savedScore < score)
-                        {
-                            PlayerPrefs.SetFloat("EasyScore", score);
-                            PlayerPrefs.Save();
-                        }
-                    }
-                    if (difficulty == "Normal")
-                    {
-                        float savedScore = PlayerPrefs.GetFloat("NormalScore", 0f);
-                        if (savedScore < score)
-                        {
-                            PlayerPrefs.SetFloat("NormalScore", score);
-                            PlayerPrefs.Save();
-                        }
-                    }
-                    if (difficulty == "Hard")
-                    {
-                        float savedScore = PlayerPrefs.GetFloat("HardScore", 0f);
-                        if (savedScore < score)
-                        {
-                            PlayerPrefs.SetFloat("HardScore", score);
-                            PlayerPrefs.Save();
-                        }
-                    }
+                    if (difficulty == "Easy") PlayerPrefs.SetFloat("EasyScore", score);
+                    if (difficulty == "Normal") PlayerPrefs.SetFloat("NormalScore", score);
+                    if (difficulty == "Hard") PlayerPrefs.SetFloat("HardScore", score);
+                    PlayerPrefs.Save();
                 }
                 scoreTxt.text = score.ToString();
+
                 endCanvas.SetActive(true);
                 Time.timeScale = 0.0f;
             }

--- a/Assets/Scripts/gameManager.cs
+++ b/Assets/Scripts/gameManager.cs
@@ -31,6 +31,8 @@ public class gameManager : MonoBehaviour
     public GameObject NowDifficulty;
     public audioManager audiomanager;
 
+    int cardCnt = 0;
+
     int mCnt = 0;
     private bool isPlay;
 
@@ -64,6 +66,8 @@ public class gameManager : MonoBehaviour
         if (difficulty == "Easy")
         {
             images = new int[10];
+            cardCnt = 10;
+
             for (int i = 0; i < 5; i++)
             {
                 images[2 * i] = (i * 3) + 1;
@@ -74,6 +78,7 @@ public class gameManager : MonoBehaviour
         else if (difficulty == "Normal")
         {
             images = new int[20];
+            cardCnt = 20;
 
             for (int i = 0; i < 5; i++)
             {
@@ -87,6 +92,8 @@ public class gameManager : MonoBehaviour
         else
         {
             images = new int[30];
+            cardCnt = 30;
+
             for (int i = 0; i < 5; i++)
             {
                 images[6 * i] = (i * 3) + 1;
@@ -190,8 +197,11 @@ public class gameManager : MonoBehaviour
             timeText.color = Color.red;
         }
 
-        if (time < 0.0f)
+        if (time <= 0.0f)
         {
+            // time set zero
+            time = 0f;
+
             remainTimeTxt.text = time.ToString("N2");
             matchCnt.text = mCnt.ToString();
 
@@ -234,6 +244,7 @@ public class gameManager : MonoBehaviour
             audioSource.PlayOneShot(match);
             firstCard.GetComponent<card>().destroyCard();
             secondCard.GetComponent<card>().destroyCard();
+            cardCnt -= 2;
             NTxt.SetActive(true);
             if (int.Parse(firstCardImage.Substring(5)) >= 13)
             {
@@ -256,10 +267,17 @@ public class gameManager : MonoBehaviour
                 nameText.text = "김성우";
             }
             Invoke("Textfalse", 0.8f);
-            int cardsLeft = GameObject.Find("cards").transform.childCount;
-            if (cardsLeft == 2)
+
+            //int cardsLeft = GameObject.Find("cards").transform.childCount;
+            //if (cardsLeft == 2)
+
+            // New type end point (cardLeft==2  ->  cardCnt==0)
+            if (cardCnt == 0)
             {
+                Time.timeScale = 0.0f;
+                timeText.text = time.ToString("N2");
                 remainTimeTxt.text = time.ToString("N2");
+
                 matchCnt.text = mCnt.ToString();
 
                 // calculate score & save
@@ -279,7 +297,6 @@ public class gameManager : MonoBehaviour
                 scoreTxt.text = score.ToString();
 
                 endCanvas.SetActive(true);
-                Time.timeScale = 0.0f;
             }
         }
         else

--- a/Assets/Scripts/gameManager.cs
+++ b/Assets/Scripts/gameManager.cs
@@ -56,15 +56,15 @@ public class gameManager : MonoBehaviour
         NowDifficulty = GameObject.Find("NowDifficulty");
         string difficulty = NowDifficulty.GetComponent<nowDifficulty>().difficulty;
 
+
         // Easy : 10 Cards(5 Types)
         if (difficulty == "Easy")
         {
             images = new int[10];
-            for (int i = 0; i < images.Length / 2; i++)
+            for (int i = 0; i < 5; i++)
             {
-                int randomValue = UnityEngine.Random.Range(0, 3);
-                images[2 * i] = i + randomValue;
-                images[2 * i + 1] = i + randomValue;
+                images[2 * i] = (i * 3) + 1;
+                images[2 * i + 1] = (i * 3) + 1;
             }
         }
         // Normal : 20 Cards(10 Types)
@@ -72,31 +72,26 @@ public class gameManager : MonoBehaviour
         {
             images = new int[20];
 
-            int value = 0;
-
-            for (int i = 0; i < images.Length / 2; i++)
+            for (int i = 0; i < 5; i++)
             {
-                images[2 * i] = value;
-                images[2 * i + 1] = value;
-
-                if (value == 1 || value == 4 || value == 7 || value == 10 || value == 13)
-                {
-                    value += 2;
-                }
-                else
-                {
-                    value += 1;
-                }
+                images[4 * i] = (i * 3) + 1;
+                images[4 * i + 1] = (i * 3) + 1;
+                images[4 * i + 2] = (i * 3) + 2;
+                images[4 * i + 3] = (i * 3) + 2;
             }
         }
         // Hard : 30 Cards(15 Types)
         else
         {
             images = new int[30];
-            for (int i = 0; i < images.Length / 2; i++)
+            for (int i = 0; i < 5; i++)
             {
-                images[2 * i] = i;
-                images[2 * i + 1] = i;
+                images[6 * i] = (i * 3) + 1;
+                images[6 * i + 1] = (i * 3) + 1;
+                images[6 * i + 2] = (i * 3) + 2;
+                images[6 * i + 3] = (i * 3) + 2;
+                images[6 * i + 4] = (i * 3) + 3;
+                images[6 * i + 5] = (i * 3) + 3;
             }
         }
 
@@ -240,7 +235,42 @@ public class gameManager : MonoBehaviour
             {
                 remainTimeTxt.text = time.ToString("N2");
                 matchCnt.text = mCnt.ToString();
-                scoreTxt.text = (50 - mCnt + Math.Round(time)).ToString();
+
+                // calculate score & save
+                int score = (50 - mCnt + (int)Math.Round(time));
+                //if (time > 0.0f)
+                if (true)
+                {
+                    string difficulty = NowDifficulty.GetComponent<nowDifficulty>().difficulty;
+                    if (difficulty == "Easy")
+                    {
+                        float savedScore = PlayerPrefs.GetFloat("EasyScore", 0f);
+                        if (savedScore < score)
+                        {
+                            PlayerPrefs.SetFloat("EasyScore", score);
+                            PlayerPrefs.Save();
+                        }
+                    }
+                    if (difficulty == "Normal")
+                    {
+                        float savedScore = PlayerPrefs.GetFloat("NormalScore", 0f);
+                        if (savedScore < score)
+                        {
+                            PlayerPrefs.SetFloat("NormalScore", score);
+                            PlayerPrefs.Save();
+                        }
+                    }
+                    if (difficulty == "Hard")
+                    {
+                        float savedScore = PlayerPrefs.GetFloat("HardScore", 0f);
+                        if (savedScore < score)
+                        {
+                            PlayerPrefs.SetFloat("HardScore", score);
+                            PlayerPrefs.Save();
+                        }
+                    }
+                }
+                scoreTxt.text = score.ToString();
                 endCanvas.SetActive(true);
                 Time.timeScale = 0.0f;
             }

--- a/Assets/Scripts/selectDifficulty.cs
+++ b/Assets/Scripts/selectDifficulty.cs
@@ -36,9 +36,9 @@ public class selectDifficulty : MonoBehaviour
         hardScore = PlayerPrefs.GetFloat("HardScore", 0f);
 
         // 각 난이도별 점수 텍스트에 반영
-        EasyScoreText.text = easyScore.ToString("F2") + " pt";
-        NormalScoreText.text = normalScore.ToString("F2") + " pt";
-        HardScoreText.text = hardScore.ToString("F2") + " pt";
+        EasyScoreText.text = easyScore.ToString("F0") + " pt";
+        NormalScoreText.text = normalScore.ToString("F0") + " pt";
+        HardScoreText.text = hardScore.ToString("F0") + " pt";
 
         // "NowDifficulty" GameObject를 찾아 저장한다
         NowDifficulty = GameObject.Find("NowDifficulty");


### PR DESCRIPTION
- 결과 데이터가 최고기록보다 클 경우 로컬 저장
- fix: MainScene 진입 시 이미지가 중복선택되던 문제 해결
- fix: 게임이 종종 끝낼 수 없는 경우가 생겨 종료 조건을 수정
- fix: 게임 실패 시 남은 시간 표기가 딱 0초가 아님 + 표기시간과 결과시간이 0.01초가량 미묘하게 다른 현상 해결

* 참고사항
- MainScene -> gameManager의 (bool)Data save with fail 에 체크v 하여 실패 시에도 데이터 저장 테스트 가능